### PR TITLE
Make GetScoreMap() return an empty map in default

### DIFF
--- a/model.go
+++ b/model.go
@@ -6,12 +6,12 @@ type Model struct {
 
 // GetKeySuffix implements the types.Model interface.
 // If you does not override this function or return empty string, it will be returned errors.
-func (b *Model) GetKeySuffix() string {
+func (m *Model) GetKeySuffix() string {
 	return ""
 }
 
 // GetScoreMap implements the types.Model interface.
 // If you does not override this function, ro.Store does not store any scores.
-func (b *Model) GetScoreMap() map[string]interface{} {
+func (m *Model) GetScoreMap() map[string]interface{} {
 	return map[string]interface{}{}
 }

--- a/model.go
+++ b/model.go
@@ -13,5 +13,5 @@ func (b *Model) GetKeySuffix() string {
 // GetScoreMap implements the types.Model interface.
 // If you does not override this function, ro.Store does not store any scores.
 func (b *Model) GetScoreMap() map[string]interface{} {
-	return nil
+	return map[string]interface{}{}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,23 @@
+package ro
+
+import (
+	"testing"
+)
+
+func TestModel_GetKeySuffix(t *testing.T) {
+	m := &Model{}
+	if got, want := m.GetKeySuffix(), ""; got != want {
+		t.Errorf("Model.GetKeySuffix() returns %q, want %q in default", got, want)
+	}
+}
+
+func TestModel_GetScoreMap(t *testing.T) {
+	m := &Model{}
+	scoreMap := m.GetScoreMap()
+	if scoreMap == nil {
+		t.Error("Model.GetScoreMap() should not be nil")
+	}
+	if got, want := len(scoreMap), 0; got != want {
+		t.Errorf("Model.GetScoreMap() has %d items, want %d items in default", got, want)
+	}
+}


### PR DESCRIPTION
In #23 , `Store#Set` do not allow `GetScoreMap()` to return `nil.